### PR TITLE
transfer_rate.sh execution

### DIFF
--- a/index.php
+++ b/index.php
@@ -137,7 +137,7 @@
            <h4>Network</h4>
 
            <?php
-            $output = shell_exec('./transfer_rate.sh');
+            $output = shell_exec('sh ./transfer_rate.sh');
             $rates = explode(' ', $output);
            ?>
 

--- a/index.php
+++ b/index.php
@@ -246,9 +246,9 @@
 
       <footer class="footer">
         <p>
-          <?php echo $_SERVER[SERVER_NAME]; ?>
+          <?php echo $_SERVER['SERVER_NAME']; ?>
            - 
-          <?php echo $_SERVER[SERVER_SOFTWARE]; ?>
+          <?php echo $_SERVER['SERVER_SOFTWARE']; ?>
         </p>
         <p>
          <?php

--- a/index.php
+++ b/index.php
@@ -9,13 +9,18 @@
     $baud = intval($baud);
     $ret = "unknown";
 
-    if ($baud > 1000){
+    if ($baud > 1000000){
+      $baud = $baud/1000000;
+      $ret = "$baud Mb/s";
+    }
+    else if ($baud > 1000){
       $baud = $baud/1000;
       $ret = "$baud Kb/s";
     }
     else{
       $ret = "$baud b/s";
     }
+
 
     return $ret;
   }


### PR DESCRIPTION
For some reason I couldn't execute the transfer_rate.sh script on my Rpi. This would result in no networking statistics. 

Also noticed some php notice errors in the logs regarding $_SERVER() key names. 

And added a next step in the pretty_baud function
