### PR TITLE
mulitple cores on RPi2  filter

### DIFF
--- a/index.php
+++ b/index.php
@@ -257,7 +257,7 @@
         </p>
         <p>
          <?php
-            $name_full = shell_exec('cat /proc/cpuinfo | grep name');
+            $name_full = shell_exec('cat /proc/cpuinfo | grep name | head -1');
             $name = explode (': ', $name_full);
             echo $name[1];
           ?>


### PR DESCRIPTION
/proc/cpuinfo returns multiple lines on RPi2, due to multiple cores i guess. This resulted in a piece of string from the second grep line to be added to $name[1]. Removed this by only outputting the first line of the grep.
