### PR TITLE
Fixed load average display

### DIFF
--- a/lib/string_helpers.php
+++ b/lib/string_helpers.php
@@ -24,9 +24,17 @@
     return $ret;
   }
 
+  // See https://en.wikipedia.org/wiki/Load_(computing)#Unix-style_load_calculation 
+  // for more info on load average % calculation
   function pretty_load_average($load_average){
-    $avg = intval(substr($load_avgerage, 0, -1));
-    $avg_percent = $avg * 100;
-    return "{$avg_percent}% Utilized";
+    $load_average = substr($load_average, 0, -1);
+    if ($load_average < 1.0) {
+      $avg_percent = (($load_average-1) * -1) * 100; // * -1 to get a positive percentage
+      return "{$avg_percent}% Idling ($load_average)";
+    }
+    else {
+      $avg_percent = ($load_average-1) * 100;
+      return "{$avg_percent}% Overloaded ($load_average)";
+    }
   }
 

--- a/lib/string_helpers.php
+++ b/lib/string_helpers.php
@@ -24,17 +24,9 @@
     return $ret;
   }
 
-  // See https://en.wikipedia.org/wiki/Load_(computing)#Unix-style_load_calculation 
-  // for more info on load average % calculation
   function pretty_load_average($load_average){
     $load_average = substr($load_average, 0, -1);
-    if ($load_average < 1.0) {
-      $avg_percent = (($load_average-1) * -1) * 100; // * -1 to get a positive percentage
-      return "{$avg_percent}% Idling ($load_average)";
-    }
-    else {
-      $avg_percent = ($load_average-1) * 100;
-      return "{$avg_percent}% Overloaded ($load_average)";
-    }
+    $avg_percent = ($load_average) * 100;
+    return "{$avg_percent}% Utilized ($load_average)";
   }
 


### PR DESCRIPTION
Hello,

Here is a new pull request to fix the load average that was not working for me.

I've fixed your **pretty_load_average** function. There was a typo and the **intval** was casting the float to and int, displaying 0% when values are at 0.05.

Also you don't need to use intvat or floatval as php will do it itself :)

I've also put back values displayed by the **loadaverage** command because I'm more used to read these values when looking a CPU load.
Feel free to remove them if you don't want to use them :)

Regards
