### PR TITLE
Fix RAM amount display css

### DIFF
--- a/content/memory.php
+++ b/content/memory.php
@@ -20,7 +20,7 @@
   <tbody>
     <tr>
       <td colspan="4">
-        <div class="row">
+        <div class="row row-memory">
           <div class="col-xs-9">
             <div class="progress">
               <div class="progress-bar progress-bar-used" 

--- a/css/custom.css
+++ b/css/custom.css
@@ -181,4 +181,7 @@ footer > p{
   } 
 }
 
-/*
+/* Fix row on memory */
+.row-memory {
+  margin-right: 0px;
+}


### PR DESCRIPTION
Hello,

It's me again, just a small fix on the CSS that display the RAM amount.

Here is what the bug looked like : ![http://mephissto.github.io/currantpi-bug-ram-display.png](http://mephissto.github.io/currantpi-bug-ram-display.png)
