### PR TITLE
Handling disk names containing a space

### DIFF
--- a/content/storage/StorageData.php
+++ b/content/storage/StorageData.php
@@ -56,7 +56,8 @@ class StorageData implements CurrantModule
 
     private function prepareColumns($row)
     {
-        return array_values(array_filter(explode(' ', $row), 'strlen'));
+        // If names of disks contain spaces (and then lower case char.), still match them as one string
+        return array_values(array_filter(preg_split('/(\s+)(?=[^a-zA-Z])/', $row), 'strlen'));
     }
 
     public function getData()


### PR DESCRIPTION
Handling disk names containing a space ("Hard drive") by replacing the splitting-line tool : explode() -> preg_split(). Otherwise the resulting table in HTML has a row mismatch.
I'm no regexp expert, so the prosed one will only match names with one space and letters after the space. Things can be improved I suppose...

Tested on RPi-2 running Raspbian Jessie with Nginx 1.6.2