### PR TITLE
Memory used 0% solve

### DIFF
--- a/content/memory/MemoryData.php
+++ b/content/memory/MemoryData.php
@@ -29,7 +29,7 @@ class MemoryData implements CurrantModule
         $mem_free = intval(shell_exec("free -m | awk '/buffers\/cache/ {print $3}'"));
         $mem_total = intval(shell_exec("free -m | awk '/Mem/ {print $2}'"));
 
-        $used_act = intval(shell_exec("free | awk '/buffers\/cache/ {print $3}'"));
+        $used_act = intval(shell_exec("free | awk '/Mem/ {print $3}'"));
         $free = intval(shell_exec("free | awk '/Mem/ {print $4}'"));
         $buffers = intval(shell_exec("free | awk '/Mem/ {print $6}'"));
         $cache = intval(shell_exec("free | awk '/Mem/ {print $7}'"));


### PR DESCRIPTION
In my raspberry pi, it always shows 0% memory used.
I think this part is the problem.

"The `procps` package was recently updated, updating `free` along with it. The updated `free` has a different output, breaking the part of the php code that relies on its output. This fix makes the php script compatable with the new `free`."